### PR TITLE
feat(support new chat): load and save session by hash from url

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -65,7 +65,7 @@ export default function (props: {
     initFromSession(getSessionKey())
   }
 
-  const initFromSession = sessionKey => {
+  const initFromSession = (sessionKey: string) => {
     const setting = localStorage.getItem("setting")
     const session = localStorage.getItem(sessionKey)
     try {

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -53,7 +53,7 @@ export default function (props: {
   )
 
   const getSessionKey = () => {
-    const sessionHash = window.location.hash
+    const sessionHash = decodeURIComponent(window.location.hash)
     if (sessionHash) {
       return "session" + sessionHash
     }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -418,6 +418,7 @@ export default function (props: {
             clear={clearSession}
             reAnswer={reAnswer}
             messaages={messageList()}
+            chatList={[]}
           />
         </Show>
         <Show

--- a/src/components/SettingAction.tsx
+++ b/src/components/SettingAction.tsx
@@ -272,7 +272,7 @@ function handleDeleteClick(name:String){
 function handleChangeChat(name:String){
   const hashValue=name=="默认对话"?"":"#"+name;
   const sessionKey="session"+hashValue
-  if(sessionKey!=window.location.hash){
+  if(sessionKey!=decodeURIComponent(window.location.hash)){
     //切换
     window.location.hash=hashValue
   }

--- a/src/components/SettingAction.tsx
+++ b/src/components/SettingAction.tsx
@@ -11,10 +11,12 @@ export default function SettingAction(props: {
   clear: any
   reAnswer: any
   messaages: ChatMessage[]
+  chatList: String[]
 }) {
   const [shown, setShown] = createSignal(false)
   const [copied, setCopied] = createSignal(false)
   const [imgCopied, setIMGCopied] = createSignal(false)
+  const [showChats, setShowChats] = createSignal(false)
   return (
     <div class="text-sm text-slate-7 dark:text-slate mb-2">
       <Show when={shown()}>
@@ -114,6 +116,22 @@ export default function SettingAction(props: {
         </SettingItem>
         <hr class="mt-2 bg-slate-5 bg-op-15 border-none h-1px"></hr>
       </Show>
+      <Show when={showChats()}>
+        <ul>
+          {props.chatList.map((item, index) => (
+            <li onClick={() => handleChangeChat(item)} >
+              <div class="flex items-center p-1 justify-between hover:bg-slate hover:bg-op-10 rounded">
+                <span ml-1>{item}</span>
+                <div class="flex items-center">
+                  <button class={"i-carbon:edit"} onClick={() => handleEditClick(item)} /> 
+                  <button class={"i-carbon:delete"} onClick={() => handleDeleteClick(item)} />             
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <hr class="mt-2 bg-slate-5 bg-op-15 border-none h-1px"></hr>
+      </Show>
       <div class="mt-2 flex items-center justify-between">
         <ActionItem
           onClick={() => {
@@ -121,6 +139,14 @@ export default function SettingAction(props: {
           }}
           icon="i-carbon:settings"
           label="设置"
+        />
+        <ActionItem
+          onClick={() => {
+            props.chatList=getChatsList();
+            setShowChats(!showChats())
+          }}
+          icon="i-carbon:chat"
+          label="聊天列表"
         />
         <div class="flex">
           <ActionItem
@@ -233,4 +259,29 @@ async function exportMD(messages: ChatMessage[]) {
       })
       .join("\n\n\n\n")
   )
+}
+
+function handleEditClick(name:String){
+
+}
+
+function handleDeleteClick(name:String){
+
+}
+
+function handleChangeChat(name:String){
+  const hashValue=name=="默认对话"?"":"#"+name;
+  const sessionKey="session"+hashValue
+  if(sessionKey!=window.location.hash){
+    //切换
+    window.location.hash=hashValue
+  }
+}
+
+function getChatsList(){
+  const sessionKeys = Object.keys(localStorage)
+    .filter(key => key.startsWith("session#"))
+    .map(key=>key.slice("session#".length))
+  sessionKeys.push("默认对话")
+  return sessionKeys
 }


### PR DESCRIPTION
Support multi chat by using hashtag in url.
Manual change/add hash tag in url to switch in diferent chats, like url#1, url#2

I also plan to add new icon to pop up a window for select chat, but I am not familer with js, it wll take long time.
I hope this can be accept first to help those people who wants multi chats.