### PR TITLE
Make send button fluently

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -475,7 +475,7 @@ export default function (props: {
                 />
               </Show>
               <div
-                class="flex text-slate-7 dark:text-slate bg-slate bg-op-15 text-op-80! hover:text-op-100! h-3em items-center rounded-r"
+                class="absolute right-2em bottom-2em text-slate-7 h-12 flex dark:text-slate text-op-80! hover:text-op-100! items-center rounded-r"
                 style={{
                   "border-top-right-radius":
                     compatiblePrompt().length === 0 ? "0.25rem" : 0


### PR DESCRIPTION
I change a little css to make send button more fulently and enhanced oneness for input textarea.
Here's **before** example
> inputting text
![YFi5nJWzFR](https://user-images.githubusercontent.com/30694270/228011052-f0c0659a-87f5-402e-bf20-0db7514fb579.jpg)

> choosing prompts
![6aQVeppKDp](https://user-images.githubusercontent.com/30694270/228011066-a4e183d8-9d97-4c78-ab14-1e977eef063f.jpg)

As we can see, there are styles gaps of input textarea between prompts and normal text.
After css adjustment:
![4f1e7030-65e9-44ab-b153-fde76b03cf52](https://user-images.githubusercontent.com/30694270/228011833-87237a7b-e487-448b-9f61-9d6fcb13f444.jpeg)
<img width="750" alt="image" src="https://user-images.githubusercontent.com/30694270/228011919-036997bc-8143-4300-b43c-17c72e4178b0.png">
even mobile side can run properly
<img width="417" alt="image" src="https://user-images.githubusercontent.com/30694270/228012047-cffca256-cba8-4c51-b5f9-60d753d809a8.png">


