### PR TITLE
chore: disable vercel-bot comments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,5 +18,8 @@
       "path": "/api/cron",
       "schedule": "0 12 * * *"
     }
-  ]
+  ],
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
禁用vercel-bot在commit中的评论，防止[恶意站点](https://github.com/lzwme/chatgpt-sites)通过爬取vercel-bot的评论中的部署链接盗用。